### PR TITLE
Fix ChanSendEmpty loop handling

### DIFF
--- a/internal/util/chan.go
+++ b/internal/util/chan.go
@@ -1,10 +1,10 @@
 package util
 
 func ChanSendEmpty[T any](ch chan T, count int) {
-	for range count {
-		var val T
-		ch <- val
-	}
+    for i := 0; i < count; i++ {
+        var val T
+        ch <- val
+    }
 }
 
 func ChanClose[T any](ch ...chan T) {

--- a/internal/util/chan_test.go
+++ b/internal/util/chan_test.go
@@ -35,15 +35,15 @@ func TestChanSendEmpty(t *testing.T) {
 
 			// Check if the correct number of values were sent
 			received := 0
-			for range tt.count {
-				select {
-				case <-ch:
-					received++
-				case <-time.After(100 * time.Millisecond):
-					t.Errorf("Timeout waiting for value")
-					return
-				}
-			}
+                        for i := 0; i < tt.count; i++ {
+                                select {
+                                case <-ch:
+                                        received++
+                                case <-time.After(100 * time.Millisecond):
+                                        t.Errorf("Timeout waiting for value")
+                                        return
+                                }
+                        }
 
 			if received != tt.expected {
 				t.Errorf("ChanSendEmpty() sent %v values; want %v", received, tt.expected)


### PR DESCRIPTION
## Summary
- fix ChanSendEmpty to iterate correctly
- update associated tests

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.0)*

------
https://chatgpt.com/codex/tasks/task_b_683f206790248331813801139b809233